### PR TITLE
Removing extra line in the end

### DIFF
--- a/jquery.autogrowtextarea.js
+++ b/jquery.autogrowtextarea.js
@@ -24,7 +24,7 @@ jQuery.fn.autoGrow = function() {
 		}
 
 		var sendContentToMirror = function (textarea) {
-			mirror.innerHTML = textarea.value.replace(/\n/g, '.<br/>.');
+			mirror.innerHTML = textarea.value.replace(/\n/g, '.<br/>.') + '.';
 			if (jQuery(textarea).height() != jQuery(mirror).height())
 				jQuery(textarea).height(jQuery(mirror).height());
 		}

--- a/jquery.autogrowtextarea.js
+++ b/jquery.autogrowtextarea.js
@@ -24,7 +24,7 @@ jQuery.fn.autoGrow = function() {
 		}
 
 		var sendContentToMirror = function (textarea) {
-			mirror.innerHTML = textarea.value.replace(/\n/g, '<br/>') + '.<br/>.';
+			mirror.innerHTML = textarea.value.replace(/\n/g, '.<br/>.');
 			if (jQuery(textarea).height() != jQuery(mirror).height())
 				jQuery(textarea).height(jQuery(mirror).height());
 		}


### PR DESCRIPTION
I changed the behaviour of the plugin so it doesn't add the extra line in the end of the textarea. I my case I needed to save some space.