### PR TITLE
padding is now applied to the mirror properly

### DIFF
--- a/jquery.autogrowtextarea.js
+++ b/jquery.autogrowtextarea.js
@@ -53,7 +53,11 @@ jQuery.fn.autoGrow = function(options) {
 		mirror.style.display = 'none';
 		mirror.style.wordWrap = 'break-word';
 		mirror.style.whiteSpace = 'normal';
-		mirror.style.padding = jQuery(this).css('padding');
+		mirror.style.padding = jQuery(this).css('paddingTop') + ' ' + 
+			jQuery(this).css('paddingRight') + ' ' + 
+			jQuery(this).css('paddingBottom') + ' ' + 
+			jQuery(this).css('paddingLeft');
+			
 		mirror.style.width = jQuery(this).css('width');
 		mirror.style.fontFamily = jQuery(this).css('font-family');
 		mirror.style.fontSize = jQuery(this).css('font-size');


### PR DESCRIPTION
jQuery's **.css('padding')** doesn't work properly in some browsers (e.g. firefox).
Here is the reference doc:
>Retrieval of shorthand CSS properties (e.g., margin, background, border), although functional with some browsers, is not guaranteed. For example, if you want to retrieve the rendered border-width, use: $( elem ).css( "borderTopWidth" ), $( elem ).css( "borderBottomWidth" ), and so on.

from: [http://api.jquery.com/css/](http://api.jquery.com/css/)