### PR TITLE
Fixed a problem where replacing spaces with `&nbsp;` caused the mirro…

### DIFF
--- a/jquery.autogrowtextarea.js
+++ b/jquery.autogrowtextarea.js
@@ -33,7 +33,6 @@ jQuery.fn.autoGrow = function(options) {
 				.replace(/'/g, '&#39;')
 				.replace(/</g, '&lt;')
 				.replace(/>/g, '&gt;')
-				.replace(/ /g, '&nbsp;')
 				.replace(/\n/g, '<br />') +
 				(settings.extraLine? '.<br/>.' : '')
 			;
@@ -52,11 +51,21 @@ jQuery.fn.autoGrow = function(options) {
 		// Style the mirror
 		mirror.style.display = 'none';
 		mirror.style.wordWrap = 'break-word';
-		mirror.style.whiteSpace = 'normal';
+		mirror.style.whiteSpace = 'pre-wrap';
 		mirror.style.padding = jQuery(this).css('paddingTop') + ' ' + 
 			jQuery(this).css('paddingRight') + ' ' + 
 			jQuery(this).css('paddingBottom') + ' ' + 
 			jQuery(this).css('paddingLeft');
+
+		mirror.style.borderStyle = jQuery(this).css('borderTopStyle') + ' ' + 
+			jQuery(this).css('borderRightStyle') + ' ' + 
+			jQuery(this).css('borderBottomStyle') + ' ' + 
+			jQuery(this).css('borderLeftStyle');
+
+		mirror.style.borderWidth = jQuery(this).css('borderTopWidth') + ' ' + 
+			jQuery(this).css('borderRightWidth') + ' ' + 
+			jQuery(this).css('borderBottomWidth') + ' ' + 
+			jQuery(this).css('borderLeftWidth');
 			
 		mirror.style.width = jQuery(this).css('width');
 		mirror.style.fontFamily = jQuery(this).css('font-family');


### PR DESCRIPTION
…r to render improperly

Replacing `/ /g` with `&nbsp` causes the spaces to never break, even when the textarea normally would break them. Therefore, I have kept the spaces as is, and instead changed the mirror's `white-space` property from `normal` to `pre-wrap`.

<img width="450" alt="screen shot 2016-11-29 at 12 01 19 am" src="https://cloud.githubusercontent.com/assets/5883448/20751297/011a2f54-b721-11e6-853f-5112698ccc07.png">

This effect compounds over several lines, and in turn the textarea grows insufficiently.